### PR TITLE
Improve shuttle dumper

### DIFF
--- a/src/DBConn/DBConn.php
+++ b/src/DBConn/DBConn.php
@@ -15,11 +15,16 @@ abstract class DBConn {
 	protected $connection;
 
 	function __construct($options) {
-		$this->host = $options['db_host'];
+		preg_match("~([A-Za-z0-9\-\.]+):?([0-9]+)?~", $options['host'], $parsed_host );
+
+		$this->host = ! empty( $parsed_host[1] ) ? $parsed_host[1] : 'localhost';
+		$this->port = ! empty( $parsed_host[2] ) ? $parsed_host[2] : 3306;
+
+		//$this->host = $options['db_host'];
+		//$this->port = $options['db_port'];
 		$this->username = $options['db_user'];
 		$this->password = $options['db_password'];
 		$this->name = $options['db_name'];
-		$this->port = $options['db_port'];
 		$this->charset = $options['charset'];
 		$this->prefix = $options['prefix'];
 	}

--- a/src/DBConn/DBConn.php
+++ b/src/DBConn/DBConn.php
@@ -25,7 +25,7 @@ abstract class DBConn {
 		$this->username = $options['db_user'];
 		$this->password = $options['db_password'];
 		$this->name = $options['db_name'];
-		$this->charset = $options['charset'];
+		$this->charset = 'utf8';
 		$this->prefix = $options['prefix'];
 	}
 

--- a/src/DBConn/DBConn.php
+++ b/src/DBConn/DBConn.php
@@ -15,7 +15,7 @@ abstract class DBConn {
 	protected $connection;
 
 	function __construct($options) {
-		preg_match("~([A-Za-z0-9\-\.]+):?([0-9]+)?~", $options['host'], $parsed_host );
+		preg_match("~([A-Za-z0-9\-\.]+):?([0-9]+)?~", $options['db_host'], $parsed_host );
 
 		$this->host = ! empty( $parsed_host[1] ) ? $parsed_host[1] : 'localhost';
 		$this->port = ! empty( $parsed_host[2] ) ? $parsed_host[2] : 3306;

--- a/src/DBConn/Mysql.php
+++ b/src/DBConn/Mysql.php
@@ -5,7 +5,7 @@ use ShuttleExport\Exception;
 
 class Mysql extends DBConn {
 	function connect() {
-		$this->connection = mysql_connect($this->host . ':' . $this->port, $this->username, $this->password);
+		$this->connection = @mysql_connect($this->host . ':' . $this->port, $this->username, $this->password);
 		if (!$this->connection) {
 			throw new Exception("Couldn't connect to the database: " . mysql_error());
 		}

--- a/src/DBConn/Mysqli.php
+++ b/src/DBConn/Mysqli.php
@@ -4,7 +4,7 @@ use ShuttleExport\Exception;
 
 class Mysqli extends DBConn {
 	function connect() {
-		$this->connection = new \MySQLi($this->host, $this->username, $this->password, $this->name, $this->port);
+		$this->connection = @new \MySQLi($this->host, $this->username, $this->password, $this->name, $this->port);
 
 		if ($this->connection->connect_error) {
 			throw new Exception("Couldn't connect to the database: " . $this->connection->connect_error);

--- a/src/Dumper/Dumper.php
+++ b/src/Dumper/Dumper.php
@@ -45,7 +45,7 @@ abstract class Dumper {
 
 	private function validate_options($db_options) {
 		$options = [
-			'db_host'        => [ 'required' => false, 'default' => '127.0.0.1' ],
+			'db_host'        => [ 'required' => false, 'default' => 'localhost' ],
 			'db_port'        => [ 'required' => false, 'default' => 3306        ],
 			'db_user'        => [ 'required' => false, 'default' => 'root'      ],
 			'db_password'    => [ 'required' => false, 'default' => ''          ],


### PR DESCRIPTION
Made the necessary changes from the previous shuttle dumper we used. Some were skipped due to the fact that some improvements related to the `mysql_set_charset` and `mysqli_set_charset` were made in the namespace version